### PR TITLE
Changing ms.prod: "msteams" to ms.service: "msteams"

### DIFF
--- a/nodejs/docfx.json
+++ b/nodejs/docfx.json
@@ -153,7 +153,7 @@
       "ms.author": "o365devx",
       "manager": "billbl",
       "ms.suite": "office365",
-      "ms.prod": "msteams",
+      "ms.service": "msteams",
       "searchScope": [
         "Teams"
       ],


### PR DESCRIPTION
This is a bulk update to change ms.prod: "msteams" to ms.service: "msteams" per ceapex Allow List request: 565923