### PR TITLE
Reinstate SDK term in landing page metadata

### DIFF
--- a/nodejs/overview/msteams-client.md
+++ b/nodejs/overview/msteams-client.md
@@ -1,7 +1,7 @@
 ---
-title: Microsoft Teams JavaScript client library
-description: Reference documentation for the latest Microsoft Teams JavaScript client library
-keywords: msteams teams client sdk javascript library reference latest
+title: Microsoft Teams SDK JavaScript client library
+description: Reference documentation for the latest Microsoft Teams SDK JavaScript client library
+keywords: sdk msteams teams client javascript library reference latest
 ---
 # Microsoft Teams JavaScript client library
 

--- a/nodejs/teams-1121/overview/msteams-client.md
+++ b/nodejs/teams-1121/overview/msteams-client.md
@@ -1,7 +1,7 @@
 ---
-title: Microsoft Teams client library version 1.12.1
-description: Reference documentation for version 1.12.1 of the Microsoft Teams client library
-keywords: msteams teams client sdk javascript library reference previous
+title: Microsoft Teams SDK JavaScript client library version 1.12.1
+description: Reference documentation for version 1.12.1 of the Microsoft Teams SDK JavaScript client library
+keywords: sdk msteams teams client javascript library reference previous
 ---
 # Microsoft Teams JavaScript client library version 1.12.1
 


### PR DESCRIPTION
To mitigate drop in search ranking for "Teams client SDK" from recent [TeamsJS terminology updates](https://github.com/MicrosoftDocs/msteams-docs/pull/7306) (SDK->library).